### PR TITLE
Updating dwardump to include quotes for application names with a space

### DIFF
--- a/lib/fastlane/plugin/upload_symbols_to_new_relic/actions/upload_symbols_to_new_relic_action.rb
+++ b/lib/fastlane/plugin/upload_symbols_to_new_relic/actions/upload_symbols_to_new_relic_action.rb
@@ -30,7 +30,7 @@ module Fastlane
       #   this might also be either nested or not, we're flexible
       def self.handle_dsym(params, current_path)
         if current_path.end_with?(".dSYM")
-          dwarf_dump = Actions.sh("xcrun dwarfdump --uuid #{current_path}")
+          dwarf_dump = Actions.sh("xcrun dwarfdump --uuid \"#{current_path}\"")
 
           upload_dsym(params, current_path, dwarf_dump)
         elsif current_path.end_with?(".zip")

--- a/lib/fastlane/plugin/upload_symbols_to_new_relic/actions/upload_symbols_to_new_relic_action.rb
+++ b/lib/fastlane/plugin/upload_symbols_to_new_relic/actions/upload_symbols_to_new_relic_action.rb
@@ -30,7 +30,7 @@ module Fastlane
       #   this might also be either nested or not, we're flexible
       def self.handle_dsym(params, current_path)
         if current_path.end_with?(".dSYM")
-          dwarf_dump = Actions.sh("xcrun dwarfdump --uuid \"#{current_path}\"")
+          dwarf_dump = Actions.sh("xcrun dwarfdump --uuid '#{current_path}'")
 
           upload_dsym(params, current_path, dwarf_dump)
         elsif current_path.end_with?(".zip")


### PR DESCRIPTION
Hey - thanks for creating the plugin!
I've got a few App Extensions in my Application that fail to upload with the following error:

```
Exit status of command 'xcrun dwarfdump --uuid AppName WatchKit Extension.appex.dSYM' was 1 instead of 0.
error: unable to open 'AppName': No such file or directory
```

Adding in escaped quotes to get around this :)
